### PR TITLE
Add support for slug options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This [remark-lint](https://github.com/wooorm/remark-lint) rule was created for [
 
 This rule checks that the top title is in the right position, and that it references the current directory name.
 
+*Options:* `exact`, `slug`, default: `exact`
+
+With default options, `exact`, checks that the exact lowercase title matches the directory name. 
+With options `slug`, checks that the slugified title matches the directory name. 
+
 Invalid, `~/example/a.md`:
 
 ```markdown
@@ -30,6 +35,16 @@ Valid, `~/example/d.md`:
 
 ```markdown
 # Example
+```
+
+Valid, `~/some-example/e.md`, with option `slug`:
+
+```markdown
+# Some Example
+```
+
+```markdown
+# Some-Example
 ```
 
 ## Using the rule

--- a/dist/appropriate-heading.js
+++ b/dist/appropriate-heading.js
@@ -5,6 +5,15 @@ var is = require('unist-util-is');
 var position = require('unist-util-position');
 var toString = require('mdast-util-to-string');
 var sep = require('path').sep;
+var slugify = require('slugify');
+
+function match(directory, title, mode) {
+  if (mode === 'exact') {
+    return directory === title;
+  }
+
+  return directory === slugify(title);
+}
 
 function appropriateHeading(tree, file, preferred) {
   var dirnames = (file.dirname === '.' ? file.cwd : file.dirname).split(sep);
@@ -19,7 +28,7 @@ function appropriateHeading(tree, file, preferred) {
   } else {
     actual = toString(head).toLowerCase();
 
-    if (actual !== expected) {
+    if (!match(expected, actual, preferred || 'exact')) {
       file.warn('Heading \'' + actual + '\' is not the directory name', head);
     }
   }

--- a/lib/appropriate-heading.js
+++ b/lib/appropriate-heading.js
@@ -3,6 +3,15 @@ const is = require('unist-util-is')
 const position = require('unist-util-position')
 const toString = require('mdast-util-to-string')
 const sep = require('path').sep
+const slugify = require('slugify')
+
+function match (directory, title, mode) {
+  if (mode === 'exact') {
+    return directory === title
+  }
+
+  return directory === slugify(title)
+}
 
 function appropriateHeading (tree, file, preferred) {
   const dirnames = (file.dirname === '.' ? file.cwd : file.dirname).split(sep)
@@ -17,7 +26,7 @@ function appropriateHeading (tree, file, preferred) {
   } else {
     actual = toString(head).toLowerCase()
 
-    if (actual !== expected) {
+    if (!match(expected, actual, preferred || 'exact')) {
       file.warn(`Heading '${actual}' is not the directory name`, head)
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/appropriate-heading.js",
   "dependencies": {
     "mdast-util-to-string": "^1.0.2",
+    "slugify": "^1.1.0",
     "unified-lint-rule": "^1.0.0",
     "unist-util-is": "^2.0.0",
     "unist-util-position": "^3.0.0"


### PR DESCRIPTION
Add a slug options.

**Options:** `exact`, `slug`, default: `exact`.
With default options, `exact`, checks that the exact lowercase title matches the directory name.
With options `slug`, checks that the slugified title matches the directory name.