### PR TITLE
Allow html comment as first line

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This rule checks that the top title is in the right position, and that it refere
 
 _Options:_ `exact`, `slug`, default: `exact`
 
-With default options, `exact`, checks that the exact lowercase title matches the directory name. 
-With options `slug`, checks that the slugified title matches the directory name. 
+With default options, `exact`, checks that the exact lowercase title matches the directory name.
+With options `slug`, checks that the slugified title matches the directory name.
 
 Invalid, `~/example/a.md`:
 

--- a/dist/appropriate-heading.js
+++ b/dist/appropriate-heading.js
@@ -8,6 +8,8 @@ var sep = require('path').sep;
 var GithubSlugger = require('github-slugger');
 var slugger = new GithubSlugger();
 
+var COMMENT = /<!--[\s\S]*-->/gm;
+
 function match(directory, title, mode) {
   if (mode === 'exact') {
     return directory === title;
@@ -16,21 +18,44 @@ function match(directory, title, mode) {
   return directory === slugger.slug(title);
 }
 
+function matchNonCommentMarker(node) {
+  if (!node || node.type !== 'html') {
+    return true;
+  }
+
+  return !node.value.match(COMMENT);
+}
+
+function startsAtBeginningOfDocument(tree, hasCommentMarker, firstNonCommentMarkerNode, firstNonCommentMarkerIndex) {
+  if (hasCommentMarker) {
+    // There should be maximum onle line between the first non-comment marker
+    // and the preceeding comment marker. We allow one line since remark introduces
+    // a newline between comment and markup when auto-formating markdown.
+    var firstLineforMarkup = position.start(firstNonCommentMarkerNode).line;
+    var lastLineForComment = position.end(tree.children[firstNonCommentMarkerIndex - 1]).line;
+    return firstLineforMarkup - lastLineForComment <= 2;
+  }
+
+  // Otherwise marker should be on first line.
+  return position.start(firstNonCommentMarkerNode).line === 1;
+}
+
 function appropriateHeading(tree, file, preferred) {
   var dirnames = (file.dirname === '.' ? file.cwd : file.dirname).split(sep);
   var expected = dirnames[dirnames.length - 1].toLowerCase();
-  var head = tree.children[0];
-  var actual = void 0;
+  var firstNonCommentMarkerIndex = tree.children.findIndex(matchNonCommentMarker);
+  var hasCommentMarker = firstNonCommentMarkerIndex > 0;
+  var firstNonCommentMarkerNode = tree.children[hasCommentMarker ? firstNonCommentMarkerIndex : 0];
 
-  if (!is('heading', head)) {
-    file.message('Document must start with a heading', head || tree);
-  } else if (position.start(head).line !== 1) {
-    file.message('Heading does not start at beginning of document', head);
+  if (!is('heading', firstNonCommentMarkerNode)) {
+    file.message('Document must start with a heading', firstNonCommentMarkerNode || tree);
+  } else if (!startsAtBeginningOfDocument(tree, hasCommentMarker, firstNonCommentMarkerNode, firstNonCommentMarkerIndex)) {
+    file.message('Heading does not start at beginning of document', firstNonCommentMarkerNode);
   } else {
-    actual = toString(head).toLowerCase();
+    var actual = toString(firstNonCommentMarkerNode).toLowerCase();
 
     if (!match(expected, actual, preferred || 'exact')) {
-      file.warn('Heading \'' + actual + '\' is not the directory name', head);
+      file.warn('Heading \'' + actual + '\' is not the directory name', firstNonCommentMarkerNode);
     }
   }
 }

--- a/lib/appropriate-heading.js
+++ b/lib/appropriate-heading.js
@@ -6,6 +6,8 @@ const sep = require('path').sep
 const GithubSlugger = require('github-slugger')
 const slugger = new GithubSlugger()
 
+const COMMENT = /<!--[\s\S]*-->/gm
+
 function match (directory, title, mode) {
   if (mode === 'exact') {
     return directory === title
@@ -14,21 +16,44 @@ function match (directory, title, mode) {
   return directory === slugger.slug(title)
 }
 
+function matchNonCommentMarker (node) {
+  if (!node || node.type !== 'html') {
+    return true
+  }
+
+  return !node.value.match(COMMENT)
+}
+
+function startsAtBeginningOfDocument (tree, hasCommentMarker, firstNonCommentMarkerNode, firstNonCommentMarkerIndex) {
+  if (hasCommentMarker) {
+    // There should be maximum one line between the first non-comment marker
+    // and the preceeding comment marker. We allow one line since remark introduces
+    // a newline between comment and markup when auto-formating markdown.
+    const firstLineforMarkup = position.start(firstNonCommentMarkerNode).line
+    const lastLineForComment = position.end(tree.children[firstNonCommentMarkerIndex - 1]).line
+    return firstLineforMarkup - lastLineForComment <= 2
+  }
+
+  // Otherwise marker should be on first line.
+  return position.start(firstNonCommentMarkerNode).line === 1
+}
+
 function appropriateHeading (tree, file, preferred) {
   const dirnames = (file.dirname === '.' ? file.cwd : file.dirname).split(sep)
   const expected = dirnames[dirnames.length - 1].toLowerCase()
-  const head = tree.children[0]
-  let actual
+  const firstNonCommentMarkerIndex = tree.children.findIndex(matchNonCommentMarker)
+  const hasCommentMarker = firstNonCommentMarkerIndex > 0
+  const firstNonCommentMarkerNode = tree.children[hasCommentMarker ? firstNonCommentMarkerIndex : 0]
 
-  if (!is('heading', head)) {
-    file.message('Document must start with a heading', head || tree)
-  } else if (position.start(head).line !== 1) {
-    file.message('Heading does not start at beginning of document', head)
+  if (!is('heading', firstNonCommentMarkerNode)) {
+    file.message('Document must start with a heading', firstNonCommentMarkerNode || tree)
+  } else if (!startsAtBeginningOfDocument(tree, hasCommentMarker, firstNonCommentMarkerNode, firstNonCommentMarkerIndex)) {
+    file.message('Heading does not start at beginning of document', firstNonCommentMarkerNode)
   } else {
-    actual = toString(head).toLowerCase()
+    const actual = toString(firstNonCommentMarkerNode).toLowerCase()
 
     if (!match(expected, actual, preferred || 'exact')) {
-      file.warn(`Heading '${actual}' is not the directory name`, head)
+      file.warn(`Heading '${actual}' is not the directory name`, firstNonCommentMarkerNode)
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -25,6 +25,25 @@ const empty = ``
 const multiWordHeading = `# Multi-Word Heading
 `
 
+const disabledHeading = `<!--lint disable appropriate-heading-->
+Paragraph
+`
+
+const allowHtmlComment = `<!-- some comment-->
+# Heading
+`
+
+const allowHtmlCommentAndOneNewLine = `<!-- some comment-->
+
+# Heading
+`
+
+const tooManyNewLinesAfterHtmlComment = `<!-- some comment-->
+
+
+# Heading
+`
+
 test('remark-lint-appropriate-heading', (t) => {
   var fp = '~/heading/readme.md'
   var mwfp = '~/multi-word-heading/readme.md'
@@ -69,6 +88,30 @@ test('remark-lint-appropriate-heading', (t) => {
     processor.processSync(vfile({path: fp, contents: empty})).messages.map(String),
     ['~/heading/readme.md:1:1-1:1: Document must start with a heading'],
     'should warn without heading'
+  )
+
+  t.deepEqual(
+    processor.processSync(vfile({path: fp, contents: disabledHeading})).messages.map(String),
+    [],
+    'should work when disabling rule'
+  )
+
+  t.deepEqual(
+    processor.processSync(vfile({path: fp, contents: allowHtmlComment})).messages.map(String),
+    [],
+    'should work with html comment'
+  )
+
+  t.deepEqual(
+    processor.processSync(vfile({path: fp, contents: allowHtmlCommentAndOneNewLine})).messages.map(String),
+    [],
+    'should work with html comment'
+  )
+
+  t.deepEqual(
+    processor.processSync(vfile({path: fp, contents: tooManyNewLinesAfterHtmlComment})).messages.map(String),
+    ['~/heading/readme.md:4:1-4:10: Heading does not start at beginning of document'],
+    'should warn if too much newlines after html comment'
   )
 
   t.end()


### PR DESCRIPTION
With the current implementation it is not possible to disable the `appropriate-heading` rule using the html comment. For instance the following will throw warning:

``` markdown
<!-- lint disable appropriate-heading-->
# remark-lint-appropriate-heading
```

This commit allows html comment in general to be present as first marker, therefore the following will be valid:

``` markdown
<!-- lint disable appropriate-heading-->
# remark-lint-appropriate-heading
```

but also

``` markdown
<!-- some other comment -->
# remark-lint-appropriate-heading
```